### PR TITLE
From soft-wrapped original text to a next draft

### DIFF
--- a/post3.md
+++ b/post3.md
@@ -1,50 +1,49 @@
 # Going Live
 
-Imagine this: You're navigating a static website in the browser. You're not scanning around with your eyeballs, though; you're navigating the elements of the document using an input device (say, a keyboard), to tell a screen reader where it should start reading next, and you receive the content as the screen reader speaks it. Good so far? 
+Imagine this: You're navigating a static website in the browser. You're not scanning around with your eyeballs, though: you're navigating the elements of the document using an input device (say, a keyboard), to tell a screen reader where it should start reading next, and you receive the content as the screen reader speaks it. Good so far? 
 
-Let's complicate the story a little. The website is now a web *app*. It has buttons or controls that may send you to another URL, or they may instigate a change to just part of the DOM. Hopefully, it's laid out so you can still find everything easily, everything behaves like what it claims to be, and nothing is lying about what it is.
+Let's complicate the story a little. The website is now a web *app*. It probably has more interactive elements, like buttons and forms, because we're (probably) doing more than reading content from top to bottom now. Hopefully, it's laid out so you can still find everything easily, everything behaves like what it claims to be, and nothing is lying about what it is.
 
-That's what we were aiming for when we [cleared the fog and picked low-hanging fruit](https://fly.io/blog/accessibility-clearing-the-fog/) in the LiveBeats UI. In the spirit of our random combo metaphor: We can see the landscape before us clearly. LiveBeats is made up of logical, well labeled parts, with well defined roles for sensible navigation and some semblance of interactivity. Now we're going to stretch a little higher up into the tree and get its real-time features working nicely with my screen reader.
+That's what we were aiming for when we [cleared the fog and picked low-hanging fruit](https://fly.io/blog/accessibility-clearing-the-fog/) in the LiveBeats UI. In the spirit of our random combo metaphor: we can see the landscape before us clearly. LiveBeats is made up of logical, well-labeled parts, with well-defined roles for sensible navigation and some semblance of interactivity. 
 
-## What lies ahead?
+We're ready to embark on our new, accessible LiveBeats adventure. But we're not in the clear yet. Now we have to stretch a little higher up into the tree and get its real-time features working nicely with my screen reader.
 
-With a clearer map, we're ready to embark on our new, accessible LiveBeats adventure. Not so fast, though. The web was never designed as an application platform. Sure, we've hacked around its many limitations and have *something* resembling interactivity. But those interactions aren't rendered by my screen reader in the same ways that a native app would be. Here are a few ways in which LiveBeats, or almost any other real-time web app, usually doesn't measure up when tested for accessibility.
+## What lies ahead? 
 
-### Routing doesn't work
+The web was never designed as an application platform. We've hacked around its limitations to get something resembling interactivity, but we're still working with something that believes, in its heart of hearts, that it's a document. Interactions still aren't rendered by my screen reader in the same ways they would be in a native app.
 
-In the web's traditional document-centric mode, clicking a link is like pulling a book off the shelf. There's a standard, boring HTTP request that retrieves an HTML payload and serves it up to the browser. It's like exchanging greetings. You almost certainly do it without thinking. Because it's such a straight-forward process, it's easy to have screen readers read out a document title and its content as soon as it loads.
+Here are a few way in which real-time web apps usually don't measure up when tested for accessibility.
 
-But there *is* no standard for live route updates. Maybe they arrive via `fetch`, or over some more exotic transport. Maybe they replace the entire page or swap out a single element. As you might imagine, throwing standards out the window tends to take accessibility along with them.
+* Route changes don't get announced
+* State changes don't get announced
+* The element the user's interacting with vanishes when activated
 
-### State isn't announced
+In the web's traditional document-centric mode, clicking a link has standard consequences. It's a like pulling a book off the shelf. The browser makes a standard HTTP request and the server sends back an HTML payload to the browser. It's safe to have a screen reader read out the document title and its content as soon as it loads.
 
-Route transitions aren't your only issue. The very nature of real-time apps means you've got status updates, chat messages, and other state changes popping in live over the wire. Automatically presenting these changes accessibly is impossible, so you'll almost certainly need to put in extra effort.
+Route changes in web apps aren't confined to any standard. They're generally not achieved by an HTML request and response, which means that the URL displayed in the browser, and all or part of the DOM, can get swapped without a screen reader noticing. When standards go out the window, accessibility often goes with them.
 
-### And then the rug gets yanked out from under you
+Live state changes are another thing that can sneak past a screen reader in a real-time app. Status updates, chat messages, etc. pop in live over the wire, and different updates may need to be handled differently. So they'll need individual attention in order to make sure they're announced in the right way.
 
-You've got your routes announcing when they've changed. You even have a bunch of fancy alerts speaking as soon as they appear. But changing the DOM is a bit like that fancy party trick where you yank off the tablecloth without taking everything on the table with it.
+However you're changing the DOM, be mindful of the focus. Live-patching the DOM is kind of like yanking a tablecloth without taking everything on the table with it. Nice! You didn't so much as spill a drink! But if a guest was admiring the fabric or dabbing at a drop of gravy, you've yoinked the thing they were doing out from under them.
 
-As you change page content by adding announcements or alerts, be mindful of the focus. If you remove the page element your user is interacting with for instance, the document may no longer be interactive without manually moving focus somewhere. I can't count how many times I navigate to the top of a document to work around having the text or button I was interacting with simply vanish without a trace. We'll get into the complexity of modals next time, but those aren't even easily interactive unless focus is intentionally moved into them.
+If you remove the page element your user is interacting with, the document may no longer be interactive without manually moving focus somewhere. I can't count how many times I've navigated to the top of a document to work around having the text or button I was interacting with simply vanish. 
 
-## Where to?
+Route changes and state announcements can both mess with focus if you don't take steps to prevent it. Don't even talk to me about modals. (Actually, we'll get into the complexity of modals next time. Spoiler: those aren't even easily interactive unless focus is intentionally moved into them.)
 
-We'll start with making LiveBeats' routing more accessible. There are a couple ways you might go about doing this.
+## Where to? (Routing)
 
-The easiest way to make routing screen reader accessible is to simply announce the page title or equivalent on transition. This gets the job done but isn't ideal. Can you guess what its biggest flaw is? Hint: we *just* alluded to it.
+Let's turn our attention to how this plays out in LiveBeats. LiveBeats is a Phoenix LiveView app, using WebSockets for client-server communication. Since we don't have a standard to tell us how to get this to work with a screen reader, we're free to choose a "standard" pattern that suits us. And we should.
 
-If you've transitioned to a new page, you've almost certainly swapped out a huge piece of content, probably taking the user's current focus along with it. You might pull a few clever focus tricks as hinted at above, but then you'll likely announce both the page title *and* the content of whatever element you chose to focus on, thus making route transitions unnecessarily chatty. And even so, you've only solved part of the problem.
+If we've transitioned to a new page, we've almost certainly swapped out a huge piece of content, probably taking the user's current focus along with it. We could emulate the HTML standard and have the page title announced on a route transition. But we'd still need to manage the focus, so we'd likely announce both the page title and the content of whatever element we chose to focus on, making route transitions unnecessarily chatty.
 
-Another common approach kills two birds with one stone. Instead of presenting the page title, move the user's focus to a standard location with a page title equivalent whenever the route changes. Not only does this announce the transition nicely, but if done well, it puts the user's focus at an ideal place to begin interacting with whatever content just loaded. We'll use this approach for LiveBeats.
+There's an approach that kills two birds with one stone: Instead of presenting the page title, move the user's focus to a standard location with a page title equivalent whenever the route changes. Not only does this announce the transition nicely, but if done well, it puts the user's focus at an ideal place to begin interacting with whatever content just loaded. We'll use this approach for LiveBeats.
 
-But there's no one correct solution for accessible routing. Someone with a cognitive disability might find sudden focus jumps hard to follow. This is why accessibility testing is crucial. Please don't assume that my advice is the final authority on the matter. I'm giving you a solid foundation, not a final destination.
+I want to stop here and emphasize that here's no one correct solution for accessible routing. Someone with a cognitive disability might find sudden focus jumps hard to follow. This is why accessibility testing is crucial. Please don't assume that my advice is the final authority on the matter.
 
-### Decide on a standard
+In LiveBeats, the content that changes when we visit a new route [is encapsulated within the `<main/>` element](https://fly.io/blog/accessibility-clearing-the-fog/). Then LiveBeats adopts the convention that the first `<h1/>` child of `<main/>` is both a suitable route title and focus target. As a fallback, if no `<h1/>` is present, focus goes directly to `<main/>`. Ideally this never happens, but as developers, we're all too aware how often things that should never happen actually *do*.
 
-Replacing one standard is usually best done with another. If you've been keeping up, you've got all you need to do this. Remember our `<main/>` element from [last time](https://fly.io/blog/accessibility-clearing-the-fog/)? LiveBeats adopts the convention that the first `<h1/>` child of the page's `<main/>` element is both a suitable route title and focus target. In cases where no `<h1/>` is present, focus directly on `<main/>`. Ideally this never happens, but as developers, we're all too aware how often things that should never happen actually *do*.
+Let's check out the LiveBeats code for focusing our chosen element. We'll use the [`HTMLElement.focus()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) method to accomplish this.
 
-### Get focused
-
-Focusing an element on route transition *seems* simple enough. There *is* a `focus()` function, after all. Not so fast, though. As with many of the web's dusty corners, there are a few rough edges you need to be aware of. Let's check out our code for focusing our chosen element, then go through it bit by bit.
 
 ```
 // Accessible focus handling
@@ -61,7 +60,9 @@ let Focus = {
 ...
 ```
 
-We start by identifying our target element, then ensure that it is non-null. Now things get odd:
+We start by identifying our target element, then ensure that it is non-null. 
+
+Then we have to deal with the fact that `focus()` doesn't let you move the caret to whatever element you want. The element has to be capable of accepting focus, meaning a [tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute must be present. So we do this little dance:
 
 ```
       let origTabIndex = target.tabIndex
@@ -70,8 +71,7 @@ We start by identifying our target element, then ensure that it is non-null. Now
       target.tabIndex = origTabIndex
 ```
 
-`focus()` doesn't let you move the caret anywhere you choose. The element has to be capable of accepting focus, meaning a
-[tabindex](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute must be present. First, we retrieve the original value which, given `<h1/>` isn't typically focusable, is usually `undefined`. Then we set it to -1, implying that we can focus the element programatically but not via tab or shift tab. Finally, we execute the focus, then reset `tabindex` to whatever value it held previously.
+We save the original value of `tabindex` which, given `<h1/>` isn't typically focusable, is usually `undefined`. Then we set it to `-1`, meaning that we can focus the element programatically but not via tab or shift-tab. Finally, we execute the focus, then reset `tabindex` to whatever value it held previously.
 
 We now have a helper function that sets focus where we want. Now we hook it into LiveView so it's called on page transition.
 
@@ -84,70 +84,47 @@ let routeUpdated = () => {
 window.addEventListener("phx:page-loading-stop", routeUpdated)
 ```
 
-Notice we hook into the `phx:page-loading-stop` event. This is because we're trying to access the DOM directly but have 2 potential sources of latency:
+There are two potential sources of delay before our DOM elements are available to focus:
 
 * Most obviously, the network adds latency by virtue of actually having to receive the data for the new route.
-* Further, any page transition animations or effects might result in DOM
-  elements not being available when you attempt to focus them.
+* Further, page transition animations or effects might result in DOM elements not being available when you attempt to focus them.
 
-Fortunately, `phx:page-loading-stop` seems to run our code at the correct time. If it doesn't, though, you may need `setTimeout` or `requestAnimationFrame` shenanigans to introduce artificial delays for transitions or effects.
+In LiveView, the `phx:page-loading-stop` event fires when the DOM is finished loading after a live redirect or DOM patch. We hook into this event to run our code at the correct time. If it doesn't, though, you may need `setTimeout` or `requestAnimationFrame` shenanigans to introduce artificial delays for transitions or effects.
 
 With this change, live route refreshes automatically move my screen reader to a good page title equivalent. Excellent!
 
-## What's up?
+## What's up? (State changes)
 
-Routing is only part of LiveBeats' story. Real-time apps often have state which changes in response to a variety of events. The most powerful tool for making these state changes accessible is the [ARIA live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
+Real-time apps often have state which changes in response to a variety of events. Some of these we'll want to know about as they happen. The most powerful tool for making these state changes accessible is the [ARIA live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions). 
 
-Connectivity is an important aspect of any real-time web app. A boring HTML page will generally continue working whether I'm on 5G or deep underground. By contrast, losing connectivity with LiveBeats means that music stops playing, buttons and links don't work and, if you haven't made your connectivity indicator accessible, screen reader users get very confused.
+Live regions give us knobs to control [how assertively their content is read](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live), [what types of changes cause the region to be read](https://fly.io/blog/accessibility-clearing-the-fog/#role-with-it-but-not-too-far), [whether changes read the entire region or just the difference](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic), [etc.](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy)
 
-We'll make LiveBeats' connection status accessible using an ARIA live region. Live regions give you bunches of knobs to control how their content is read,
-what types of changes cause the region to be read, whether changes read the entire region or just the difference, etc. For the sake of this example, we'll keep it simple:
+Remember [roles](https://fly.io/blog/accessibility-clearing-the-fog/#role-with-it-but-not-too-far)? The [`alert` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role) is a shorthand for live region settings appropriate for important, usually time-sensitive, information. Changes to such an area will be read out immediately, cutting off any existing screen reader speech if necessary.
 
-```
-  def connection_status(assigns) do
-    ~H"""
-    <div
-      id="connection-status"
-      class="hidden rounded-md bg-red-50 p-4 fixed top-1 right-1 w-96 fade-in-scale z-50"
-      js-show={show("#connection-status")}
-      js-hide={hide("#connection-status")}
-    >
-      <div class="flex">
-        <div class="flex-shrink-0">
-          <svg class="animate-spin -ml-1 mr-3 h-5 w-5 text-red-800" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-          </svg>
-        </div>
-        <div class="ml-3">
-          <p class="text-sm font-medium text-red-800" role="alert">
-            <%= render_slot(@inner_block) %>
-          </p>
-        </div>
-      </div>
-    </div>
-    """
-  end
-```
+"Cutting off any existing screen reader speech if necessary" means exactly that. With great power comes great responsibility. I see web developers use live regions for *any* section of the page that changes. Carousels and slideshows are the most common abuse. Please only use live regions for changes that benefit me if reported immediately. Incoming alert? Great. Ad banners? Not so much.
 
-That's a *lot* of code. Surprisingly, the only bit relevant to accessibility is:
+One thing I do want to hear about immediately is when my real-time web app loses connectivity. A boring HTML page will generally continue working whether I'm on 5G or deep underground. By contrast, losing connectivity with LiveBeats means that music stops playing, buttons and links don't work and, if you haven't made your connectivity indicator accessible, screen reader users get very confused.
+
+Let's make LiveBeats' connection status accessible using `role="alert"`. Here's the only part of the [connection status indicator](https://github.com/fly-apps/live_beats/blob/6b02cfc614aaf1f7a5ebc595c435bf62a65f5bcb/lib/live_beats_web/live/live_helpers.ex#L27) relevant to accessibility:
 
 ```
-          <p class="text-sm font-medium text-red-800" role="alert">
-            <%= render_slot(@inner_block) %>
-          </p>
+<p class="text-sm font-medium text-red-800" role="alert">
+  <%%= render_slot(@inner_block) %>
+</p>
 ```
 
-Remember roles? The [`alert` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role) marks an area of the page as being for important, usually time-sensitive, information. Any content rendered to this element will be read out immediately, cutting off any existing screen reader speech if necessary.
+Deciding which live region settings were appropriate was most of the work! An incoming chat message could probably afford to [wait for other announcements to finish](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live), and maybe you don't even need to know every time another visits or leaves your playlist. In a music-player app, you really don't want too many status announcements interrupting the tunes.
 
-Let me reiterate. "Cutting off any existing screen reader speech if necessary" means exactly that. With great power comes great responsibility. I see web
-developers use live regions for *any* section of the page that changes. Carousels and slideshows are the most common abuse. Please only use live regions for changes that benefit me if reported immediately. Incoming alert? Great. Ad banners? Not so much.
+## Ephemeral alerts
 
-Live regions work well for the obvious case of reading content that changes. Buthow do you present updates and alerts that *aren't* associated with an area onthe page? Say someone's post is liked or favorited in your new fancy social networking app. You may never display the text "Alice likes your post," but you might still want to make that accessible. Or maybe you convey something visually, like a greyed-out icon for a dropped connection and want to speak an alert whenever the icon's color changes.
+Live regions work well for the obvious case of reading content that changes. But how do you present updates and alerts that *aren't* associated with an area on the page? Say someone's post is liked or favorited in your new fancy social networking app. You may never display the text "Alice likes your post," but you might still want to make that accessible. Or maybe you convey something visually with a symbol but no text; say, a greyed-out icon for a dropped connection; and want to speak an alert whenever the icon's color changes.
 
-The solution here is an [off-screen live region specifically for announcements](https://stackoverflow.com/questions/50747587/announce-aria-live-text-change-despite-div-being-hidden). One step developers often miss when taking this approach is that of clearing the announcement live region after a reasonable timeout. Without this, the text of. the most recent announcement hangs around in the DOM, usually at the end, and can confuse screen reader users who navigate to the bottom of the page only to find one or more earlier announcements in the page text. Slap a long `setTimeout` to give screen readers enough time to read the text--15 seconds should be sufficient.
+The solution here is an [off-screen live region specifically for announcements](https://stackoverflow.com/questions/50747587/announce-aria-live-text-change-despite-div-being-hidden).
+
+One step developers often miss with this kind of announcement is to clear the live region after a reasonable timeout--it's still hanging around the DOM after it's spoken, usually at the end, waiting to surprise screen reader users when they navigate to the bottom of the page.
+ 
+Slap a long `setTimeout` to give screen readers enough time to read the text; 15 seconds should be sufficient.
 
 ## Conclusion
 
-We've done a *lot* to make LiveBeats more screen reader accessible, but there's one piece missing. Uploading songs opens a modal dialog, and these are unfortunately not very accessible without quite a bit of effort. Making these accessible draws on just about every technique we've covered so far, so stick around! And, as always, thanks for taking the time to learn more about
-accessibility.
+We've done a *lot* to make LiveBeats more screen reader accessible, but there's one piece missing. Uploading songs opens a modal dialog, and these are unfortunately not very accessible without quite a bit of effort. Making these accessible draws on just about every technique we've covered so far, so stick around! And, as always, thanks for taking the time to learn more about accessibility.


### PR DESCRIPTION
Main aims of these changes:

1. to arrange information so that people (like me) who aren't that familiar with how screen readers and/or real-time apps work can follow
2. to fill in mechanisms for how things work (or fail)
3. to tighten up wordings

Because I added things, it's worth making sure I didn't skew the meanings of any points.